### PR TITLE
memBase from NumericalSolution.py is Profiling.memLast inside the con…

### DIFF
--- a/proteus/MeshTools.py
+++ b/proteus/MeshTools.py
@@ -6966,7 +6966,7 @@ def _generateMesh(domain,meshOptions,generatePartitionedMeshFromFiles=False):
                     if generatePartitionedMeshFromFiles:
                         if comm.isMaster():
                             globalMesh = TetrahedralMesh()
-                            logEvent(Profiling.memory("Before Generating Mesh", className="NumericalSolution", memSaved=memBase))
+                            logEvent(Profiling.memory("Before Generating Mesh", className="NumericalSolution", memSaved=Profiling.memLast))
                             memBeforeMesh = Profiling.memLast
                             logEvent("Generating tetrahedral mesh from regular grid")
                             globalMesh.generateTetrahedralMeshFromRectangularGrid(nnx, nny,nnz,domain.L[0],domain.L[1],domain.L[2])


### PR DESCRIPTION
…structor (equal to 0.0). When I switched memBase to Profiling.memLast to get rid of the NameError, it seemed to run fine. I don't know what the significance of memBase is, but it wasn't being used anywhere outside of log statements from what I could tell.

# Mandatory Checklist

Please ensure that the following criteria are met:

- [ ] Title of pull request describes the changes/features
- [ ] Request at least 2 reviewers
- [ ] If new files are being added, the files are no larger than 100kB. Post the file sizes.
- [ ] Code coverage did not decrease. If this is a bug fix, a test should cover that bug fix. If a new feature is added, a test should be made to cover that feature.
- [ ] New features have appropriate documentation strings (readable by sphinx)
- [ ] Contributor has read and agreed with CONTRIBUTING.md and has added themselves to CONTRIBUTORS.md 

As a general rule of thumb, try to follow [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines.

# Description
